### PR TITLE
Local path to social-context bundle in adjecent ad4m-cli repo

### DIFF
--- a/apps/tree-of-life/ad4m/index.ts
+++ b/apps/tree-of-life/ad4m/index.ts
@@ -72,10 +72,12 @@ async function xxx() {
   console.log(links);
 
   const uniqueLinkLanguage = await ad4mClient.languages.cloneHolochainTemplate(
-    path.join(__dirname, "../languages/social-context"),
+    path.join(__dirname, "../../../../ad4m-cli/src/builtin-langs/social-context"),
     "social-context",
     "b98e53a8-5800-47b6-adb9-86d55a74871e"
   );
+
+  console.log("uniqueLinkLanguage:", uniqueLinkLanguage)
 }
 
 xxx();


### PR DESCRIPTION
Until Josh finishes implementing the new Language templating spec, we have to provide a local path to the language bundle file that we are cloning/templating. This is pointing to the social-context language bundle in the ad4m-cli repo that I have cloned next to this repo.

Best solution would be to also download this file from https://github.com/juntofoundation/Social-Context/releases in a setup step in this repo, as is done in ad4m-cli with this script: https://github.com/perspect3vism/ad4m-cli/blob/develop/scripts/get-builtin-langs.js